### PR TITLE
hpq.py: Replace recv_frame with recv_data_frame

### DIFF
--- a/hpq.py
+++ b/hpq.py
@@ -53,7 +53,7 @@ class WebSocketClient:
     def __init__(self):
         self.url = "wss://mdx.uat.maystreet.com"
         """The url to connect to. Defaults to the HPQ UAT environment."""
-        self.init_opts = {}
+        self.init_opts = {"fire_cont_frame":True}
         """A dictionary of options which will be expanded and forwarded when calling
         websocket.WebSocket.__init__."""
         self.socket = None
@@ -131,7 +131,7 @@ class WebSocketClient:
         """Streams the next JSON frame of the response.
 
         Returns the data associated with the received WebSocket frame."""
-        self.frame = self.socket.recv_frame()
+        self.frame = self.socket.recv_data_frame()[1]
         if self.finished_response():
             self.__state = WebSocketClient.__after_response
 


### PR DESCRIPTION
Previously, the streaming WebSocket API for HPQ would rely on the recv_frame() method to acquire individual data frames of the response from the router API. Unfortunately, this would result in flaky outcomes where some queries would fail with exceptions like the following:

  File "/usr/lib/python3/dist-packages/websocket/_abnf.py", line 421, in validate
    raise WebSocketProtocolException("Illegal frame")

This is because it was mixing the high-level recv() method with the low-level recv_frame() method, and the low-level API bypasses the websocket-client library's internal sanity checking, causing it to become confused and think that the router was sending continuation frames without a preceding text/binary frame.

This commit addresses the issue by replacing the use of recv_frame() with recv_data_frame() and setting the WebSocket object to be initialized with the fire_cont_frame parameter set to True; this configuration allows us to make use of the high-level API to fetch individual frames, avoiding confusing the sanity checker, without actually buffering the entire WebSocket message.

For more details, see
https://github.com/websocket-client/websocket-client/issues/688#issue-880079946.